### PR TITLE
Make a few adjustments

### DIFF
--- a/drivers/block/nbd.c
+++ b/drivers/block/nbd.c
@@ -792,6 +792,7 @@ static int __init nbd_init(void)
 		 * Tell the block layer that we are not a rotational device
 		 */
 		queue_flag_set_unlocked(QUEUE_FLAG_NONROT, disk->queue);
+		queue_flag_clear_unlocked(QUEUE_FLAG_ADD_RANDOM, disk->queue);
 	}
 
 	if (register_blkdev(NBD_MAJOR, "nbd")) {

--- a/drivers/cpufreq/cpu_input_boost.c
+++ b/drivers/cpufreq/cpu_input_boost.c
@@ -231,7 +231,8 @@ static int fb_unblank_boost(struct notifier_block *nb,
 }
 
 static struct notifier_block fb_boost_nb = {
-	.notifier_call = fb_unblank_boost,
+	.notifier_call	= fb_unblank_boost,
+	.priority	= INT_MAX,
 };
 
 static void cpu_ib_input_event(struct input_handle *handle, unsigned int type,

--- a/drivers/s390/block/xpram.c
+++ b/drivers/s390/block/xpram.c
@@ -343,6 +343,7 @@ static int __init xpram_setup_blkdev(void)
 			put_disk(xpram_disks[i]);
 			goto out;
 		}
+		queue_flag_clear_unlocked(QUEUE_FLAG_ADD_RANDOM, xpram_queues[i]);
 		blk_queue_make_request(xpram_queues[i], xpram_make_request);
 		blk_queue_logical_block_size(xpram_queues[i], 4096);
 	}

--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -432,7 +432,7 @@ struct request_queue {
 #define QUEUE_FLAG_SAME_FORCE  18	/* force complete on same CPU */
 #define QUEUE_FLAG_SANITIZE    19	/* supports SANITIZE */
 
-#define QUEUE_FLAG_DEFAULT	((1 << QUEUE_FLAG_IO_STAT) |		\
+#define QUEUE_FLAG_DEFAULT	((0 << QUEUE_FLAG_IO_STAT) |		\
 				 (1 << QUEUE_FLAG_STACKABLE)	|	\
 				 (1 << QUEUE_FLAG_SAME_COMP)	|	\
 				 (1 << QUEUE_FLAG_ADD_RANDOM))


### PR DESCRIPTION
The CPU input boost and simple thermal commits were picked from your kernel for the OnePlus 3 as they appear to work and to be applicable here. Since TSENS is not used by your thermal driver, there is no reason to call it anymore so I removed it's initialization. Furthermore, I disabled IO stats and add random as they are not really beneficial on MMC devices, and IO stats only serves the purpose of monitoring transfer speeds which is just using up resources that we do not need in a kernel intended for daily use. Disabling the CRC check also lead to higher speeds when testing with my modified version of your kernel as well. Finally, I added back Smartmax. It appeared as though you had tried to get it working right for Bacon at an earlier stage, but never could. DerRomtester seems to have successfully fixed it for use with your kernel and it has worked flawlessly for me over the months

Merry Christmas ;)